### PR TITLE
Update 064-cluster-data_protection-import.sh

### DIFF
--- a/064-cluster-data_protection-import.sh
+++ b/064-cluster-data_protection-import.sh
@@ -18,7 +18,7 @@ DRYRUN=
 
 # Support linux only, for MacOS, please use 'gsed' instead
 echo "Updating orgId in files ......"
-ORGID=$(TANZU tmc management-cluster get attached | yq ".fullName.orgId")
+ORGID=$(${TANZU} tmc management-cluster get attached | yq ".fullName.orgId")
 grep "orgId: " ${DPDIR}/* -r
 find ${DPDIR} -name "*.yaml" -exec sed -i "s/orgId: .*/orgId: ${ORGID}/g" {} \;
 grep "orgId: " ${DPDIR}/* -r


### PR DESCRIPTION
Fixed error:
ORGID=$(TANZU tmc management-cluster get attached | yq ".fullName.orgId") TO
ORGID=$(${TANZU} tmc management-cluster get attached -o yaml | yq -r '.fullName.orgId')